### PR TITLE
Fix Timer.after closure retain cycle

### DIFF
--- a/Source/CocoaMQTTFrame.swift
+++ b/Source/CocoaMQTTFrame.swift
@@ -461,11 +461,10 @@ open class CocoaMQTTFrameBuffer: NSObject {
         
         send(frame)
         
-        Timer.after(timeout.seconds) {
-            if let msgid = frame.msgid {
-                if self.removeFrameFromSilos(withMsgid: msgid) {
-                    printDebug("timeout of frame:\(msgid)")
-                }
+       Timer.after(timeout.seconds) { [weak self, weak frame] in
+            guard let msgid = frame?.msgid else {return}
+            if self?.removeFrameFromSilos(withMsgid: msgid) == true {
+                printDebug("timeout of frame:\(msgid)")
             }
         }
         


### PR DESCRIPTION
The Timer.after function accept a escaped closure.
tryTransport() use Timer.after and the closure used capture self and frame which are not escaped. 
When checking in memory graph the CocoaMQTTFrame class is retained even when it should be deallocated, the closure is retaining it. 

This fix add self and frame in the capture list of the closure and guard them to ensure they are not nil

